### PR TITLE
- fixed potential .3dw mesh scale/rotation corruption

### DIFF
--- a/Sledge.Providers/Map/L3DWProvider.cs
+++ b/Sledge.Providers/Map/L3DWProvider.cs
@@ -174,7 +174,7 @@ namespace Sledge.Providers.Map
                     float roll = br.ReadSingle();
                     newProperty = new Property();
                     newProperty.Key = "angles";
-                    newProperty.Value = pitch.ToString()+" "+yaw.ToString()+" "+roll.ToString();
+                    newProperty.Value = pitch.ToString().Replace(',', '.') + " "+yaw.ToString().Replace(',', '.') + " "+roll.ToString().Replace(',', '.');
 
                     entity.EntityData.Properties.Add(newProperty);
 
@@ -191,7 +191,7 @@ namespace Sledge.Providers.Map
 
                     newProperty = new Property();
                     newProperty.Key = "scale";
-                    newProperty.Value = xScale.ToString() + " " + yScale.ToString() + " " + zScale.ToString();
+                    newProperty.Value = xScale.ToString().Replace(',', '.') + " " + yScale.ToString().Replace(',', '.') + " " + zScale.ToString().Replace(',', '.');
 
                     entity.EntityData.Properties.Add(newProperty);
 

--- a/Sledge.Providers/Map/L3DWProvider.cs
+++ b/Sledge.Providers/Map/L3DWProvider.cs
@@ -174,7 +174,7 @@ namespace Sledge.Providers.Map
                     float roll = br.ReadSingle();
                     newProperty = new Property();
                     newProperty.Key = "angles";
-                    newProperty.Value = pitch.ToString().Replace(',', '.') + " "+yaw.ToString().Replace(',', '.') + " "+roll.ToString().Replace(',', '.');
+                    newProperty.Value = pitch.ToString(CultureInfo.InvariantCulture) + " "+yaw.ToString(CultureInfo.InvariantCulture) + " "+roll.ToString(CultureInfo.InvariantCulture);
 
                     entity.EntityData.Properties.Add(newProperty);
 
@@ -191,7 +191,7 @@ namespace Sledge.Providers.Map
 
                     newProperty = new Property();
                     newProperty.Key = "scale";
-                    newProperty.Value = xScale.ToString().Replace(',', '.') + " " + yScale.ToString().Replace(',', '.') + " " + zScale.ToString().Replace(',', '.');
+                    newProperty.Value = xScale.ToString(CultureInfo.InvariantCulture) + " " + yScale.ToString(CultureInfo.InvariantCulture) + " " + zScale.ToString(CultureInfo.InvariantCulture);
 
                     entity.EntityData.Properties.Add(newProperty);
 


### PR DESCRIPTION
Depending on culture either '.' or ',' are used, as seperators in decimal numbers, but Sledge only recognizes '.'.